### PR TITLE
Bail if $current_screen is not an object

### DIFF
--- a/comments-not-replied-to.php
+++ b/comments-not-replied-to.php
@@ -369,7 +369,7 @@ class Comments_Not_Replied_To {
 		// only run this on the comments table
 		$current_screen = get_current_screen();
 
-		if( 'edit-comments' !== $current_screen->base ) {
+		if( ! is_object( $current_screen ) || 'edit-comments' !== $current_screen->base ) {
 			return;
 		} // end if
 


### PR DESCRIPTION
To resolve a number of notices in my error logs, a la:

```PHP message: PHP Notice:  Trying to get property of non-object in /srv/www/html/wp-content/plugins/comments-not-replied-to/comments-not-replied-to.php on line 361" while reading response header from upstream, client: xx, server: , request: "GET /wp-admin/admin-ajax.php?action=get_attachment_comments&nonce=1&id=33421&offset=0 HTTP/2.0",```